### PR TITLE
add lumine mirror repo and support Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
 	</dependencies>
 	<repositories>
 		<repository>
+			<id>lumine</id>
+			<url>https://mvn.lumine.io/repository/maven-public/</url>
+		</repository>
+		<repository>
 			<id>minecraft-repo</id>
 			<url>https://libraries.minecraft.net/</url>
 		</repository>


### PR DESCRIPTION
We don't need to build spigot in local environment by using a mirror repository.
And I add jitpack properties to allow CMILib to be easier to depend on. Add local jar file dependency is inconvenient and I think it is stupid. I am not capable to upload it to an maven repository. So I think that Jitpack is a good choice.