### PR TITLE
Fixed chunk loading issue on Folia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+.idea/
+CMILib.iml

--- a/src/main/java/net/Zrips/CMILib/CMILib.java
+++ b/src/main/java/net/Zrips/CMILib/CMILib.java
@@ -38,6 +38,8 @@ public class CMILib extends JavaPlugin {
     public static final String translationsFolderName = "Translations";
     public static final String itemsFolderName = "Items";
 
+    public static Boolean isFolia;
+
     private static CMILib instance;
 
     private boolean cmiPresent = false;
@@ -249,6 +251,14 @@ public class CMILib extends JavaPlugin {
     public void onEnable() {
 
         instance = this;
+
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServerInitEvent");
+            isFolia = true;
+        } catch (ClassNotFoundException e) {
+            isFolia = false;
+        }
+
         this.getItemManager().load();
         this.getConfigManager().load();
         this.getItemManager().loadLocale();

--- a/src/main/java/net/Zrips/CMILib/Items/CMIMaterial.java
+++ b/src/main/java/net/Zrips/CMILib/Items/CMIMaterial.java
@@ -6,9 +6,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Skull;
@@ -16,7 +19,6 @@ import org.bukkit.inventory.ItemStack;
 
 import net.Zrips.CMILib.CMILib;
 import net.Zrips.CMILib.Container.CMIText;
-import net.Zrips.CMILib.Logs.CMIDebug;
 import net.Zrips.CMILib.Version.Version;
 
 public enum CMIMaterial {
@@ -1861,6 +1863,22 @@ public enum CMIMaterial {
         }
 
         if (Version.isCurrentEqualOrHigher(Version.v1_14_R1)) {
+            if (CMILib.isFolia) {
+                // Invoke World#getChunkAtAsync to load chunk off-main
+                Future<Chunk> future = block.getWorld().getChunkAtAsync(block);
+                Chunk chunk;
+
+                try {
+                    chunk = future.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (!chunk.isLoaded()) {
+                    return null;
+                }
+            }
+
             CMIMaterial res = ItemManager.byRealMaterial.get(block.getType());
             return res == null ? CMIMaterial.NONE : res;
         }


### PR DESCRIPTION
`CMIMaterial#get` method invokes a `Block#getType`, which will load the chunk.
```java
CMIMaterial res = ItemManager.byRealMaterial.get(block.getType());
```
Folia seems don't allowed plugins to load chunks in main thread, so this patch simply fixed this by invoke a Paper-provided method (`World#getChunkAtAsync`) to load the chunk asynchronously before the `Block#getType` invocation.