### PR TITLE
Performance and thread-safety improvements

### DIFF
--- a/src/main/java/net/Zrips/CMILib/Advancements/CMIAdvancement.java
+++ b/src/main/java/net/Zrips/CMILib/Advancements/CMIAdvancement.java
@@ -258,10 +258,11 @@ public class CMIAdvancement {
         add();
         grant(players);
         final CMIAdvancement ad = this;
-        CMIScheduler.runTaskLater(() -> {
-            revoke(players);
-            CMILib.getInstance().getReflectionManager().removeAdvancement(ad);
-        }, 20L);
+        for (Player player : players) {
+            final Player one = player;
+            CMIScheduler.runAtEntityLater(one, () -> revoke(one), 20L);
+        }
+        CMIScheduler.runTaskLater(() -> CMILib.getInstance().getReflectionManager().removeAdvancement(ad), 40L);
         return this;
     }
 

--- a/src/main/java/net/Zrips/CMILib/BossBar/BossBarManager.java
+++ b/src/main/java/net/Zrips/CMILib/BossBar/BossBarManager.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;
@@ -30,8 +31,10 @@ public class BossBarManager {
 
     ConcurrentHashMap<UUID, ConcurrentHashMap<String, BossBarInfo>> barMap = new ConcurrentHashMap<UUID, ConcurrentHashMap<String, BossBarInfo>>();
 
+    private static final Pattern CLEAN = Pattern.compile("[^a-zA-Z0-9]");
+
     private static String cleanName(String name) {
-        return name.replaceAll("[^a-zA-Z0-9]", "");
+        return CLEAN.matcher(name).replaceAll("");
     }
 
     public synchronized void addGlobalBar(BossBarInfo binfo) {

--- a/src/main/java/net/Zrips/CMILib/Chat/ChatFilterRule.java
+++ b/src/main/java/net/Zrips/CMILib/Chat/ChatFilterRule.java
@@ -80,8 +80,9 @@ public class ChatFilterRule {
     public Matcher getMatcher(String msg) {
 	Matcher matcher = null;
 	for (Pattern one : pattern) {
-	    if (one.matcher(msg).find()) {
-		matcher = one.matcher(msg);
+	    Matcher m = one.matcher(msg);
+	    if (m.find()) {
+		matcher = m.reset();
 		break;
 	    }
 	}

--- a/src/main/java/net/Zrips/CMILib/Container/CMIBlock.java
+++ b/src/main/java/net/Zrips/CMILib/Container/CMIBlock.java
@@ -29,8 +29,10 @@ public class CMIBlock {
             return dir;
         }
 
+        private static final blockDirection[] VALUES = values();
+
         public static blockDirection getByDir(int dir) {
-            for (blockDirection one : blockDirection.values()) {
+            for (blockDirection one : VALUES) {
                 if (one.getDir() == dir)
                     return one;
             }
@@ -70,8 +72,10 @@ public class CMIBlock {
         OUTER_RIGHT,
         STRAIGHT;
 
+        private static final StairShape[] VALUES = values();
+
         public static StairShape getByName(String name) {
-            for (StairShape one : StairShape.values()) {
+            for (StairShape one : VALUES) {
                 if (one.toString().equalsIgnoreCase(name))
                     return one;
             }
@@ -2062,7 +2066,6 @@ public class CMIBlock {
         if (block.getState() instanceof InventoryHolder) {
             try {
                 block.getChunk().load(false);
-                block.getChunk().setForceLoaded(true);
             } catch (Throwable e) {
 
             }

--- a/src/main/java/net/Zrips/CMILib/Container/CMICuboidArea.java
+++ b/src/main/java/net/Zrips/CMILib/Container/CMICuboidArea.java
@@ -103,10 +103,10 @@ public class CMICuboidArea {
         boolean found = false;
         int it = 0;
         int maxIt = 30;
+        Random ran = new Random();
         while (!found && it < maxIt) {
             it++;
 
-            Random ran = new Random(System.currentTimeMillis());
             if (randomLocList.isEmpty())
                 break;
             int check = ran.nextInt(randomLocList.size());
@@ -125,8 +125,8 @@ public class CMICuboidArea {
             for (int i = max; i > getLowPoint().getY(); i--) {
                 loc.setY(i);
                 Block block = loc.getBlock();
-                Block block2 = loc.clone().add(0, 1, 0).getBlock();
-                Block block3 = loc.clone().add(0, -1, 0).getBlock();
+                Block block2 = loc.getWorld().getBlockAt(loc.getBlockX(), i + 1, loc.getBlockZ());
+                Block block3 = loc.getWorld().getBlockAt(loc.getBlockX(), i - 1, loc.getBlockZ());
                 if (block3.getType() != Material.AIR && block.getType() == Material.AIR && block2.getType() == Material.AIR) {
                     break;
                 }

--- a/src/main/java/net/Zrips/CMILib/Container/CMILocation.java
+++ b/src/main/java/net/Zrips/CMILib/Container/CMILocation.java
@@ -279,12 +279,14 @@ public class CMILocation extends Location {
 
         ChunkSnapshot chunkSnapshot = null;
 
-        if (!world.getBlockAt(x, 0, z).getChunk().isLoaded()) {
-            world.getBlockAt(x, 0, z).getChunk().load();
-            chunkSnapshot = world.getBlockAt(x, 0, z).getChunk().getChunkSnapshot(false, false, false);
-            world.getBlockAt(x, 0, z).getChunk().unload();
+        Chunk chunk = world.getBlockAt(x, 0, z).getChunk();
+
+        if (!chunk.isLoaded()) {
+            chunk.load();
+            chunkSnapshot = chunk.getChunkSnapshot(false, false, false);
+            chunk.unload();
         } else {
-            chunkSnapshot = world.getBlockAt(x, 0, z).getChunk().getChunkSnapshot();
+            chunkSnapshot = chunk.getChunkSnapshot();
         }
 
         if (chunkSnapshot == null)

--- a/src/main/java/net/Zrips/CMILib/Container/CuboidArea.java
+++ b/src/main/java/net/Zrips/CMILib/Container/CuboidArea.java
@@ -103,10 +103,10 @@ public class CuboidArea {
         boolean found = false;
         int it = 0;
         int maxIt = 30;
+        Random ran = new Random();
         while (!found && it < maxIt) {
             it++;
 
-            Random ran = new Random(System.currentTimeMillis());
             if (randomLocList.isEmpty())
                 break;
             int check = ran.nextInt(randomLocList.size());
@@ -125,8 +125,8 @@ public class CuboidArea {
             for (int i = max; i > getLowPoint().getY(); i--) {
                 loc.setY(i);
                 Block block = loc.getBlock();
-                Block block2 = loc.clone().add(0, 1, 0).getBlock();
-                Block block3 = loc.clone().add(0, -1, 0).getBlock();
+                Block block2 = loc.getWorld().getBlockAt(loc.getBlockX(), i + 1, loc.getBlockZ());
+                Block block3 = loc.getWorld().getBlockAt(loc.getBlockX(), i - 1, loc.getBlockZ());
                 if (block3.getType() != Material.AIR && block.getType() == Material.AIR && block2.getType() == Material.AIR) {
                     break;
                 }

--- a/src/main/java/net/Zrips/CMILib/FileDownloader.java
+++ b/src/main/java/net/Zrips/CMILib/FileDownloader.java
@@ -75,7 +75,7 @@ public class FileDownloader {
                     CMIMessages.consoleMessage("You can do it manually, try again later or simply ignore it.");
                 }
 
-                FileDownloader.this.failedDownload();
+                CMIScheduler.runTask(FileDownloader.this::failedDownload);
             } finally {
                 if (fileOutputStream != null)
                     try {

--- a/src/main/java/net/Zrips/CMILib/Future/CMIFutureBatcher.java
+++ b/src/main/java/net/Zrips/CMILib/Future/CMIFutureBatcher.java
@@ -3,10 +3,11 @@ package net.Zrips.CMILib.Future;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CMIFutureBatcher {
     private Queue<CompletableFuture<?>> queue = new ConcurrentLinkedQueue<>();
-    private boolean running = false;
+    private final AtomicBoolean running = new AtomicBoolean(false);
     private int delayBetweenBatches = 0;
 
     public CMIFutureBatcher() {
@@ -24,26 +25,30 @@ public class CMIFutureBatcher {
     }
 
     public void processQueue() {
-        if (running && !queue.isEmpty())
+        if (!running.compareAndSet(false, true))
             return;
-        running = true;
         CompletableFuture.runAsync(() -> {
-            while (!queue.isEmpty()) {
-                CompletableFuture<?> future = queue.poll();
+            while (true) {
+                while (!queue.isEmpty()) {
+                    CompletableFuture<?> future = queue.poll();
 
-                if (future == null)
-                    break;
+                    if (future == null)
+                        break;
 
-                if (delayBetweenBatches > 0)
-                    try {
-                        Thread.sleep(delayBetweenBatches);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                        Thread.currentThread().interrupt();
-                    }
-                future.complete(null);
+                    if (delayBetweenBatches > 0)
+                        try {
+                            Thread.sleep(delayBetweenBatches);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                            Thread.currentThread().interrupt();
+                        }
+                    future.complete(null);
+                }
+                running.set(false);
+                if (!queue.isEmpty() && running.compareAndSet(false, true))
+                    continue;
+                break;
             }
-            running = false;
         });
     }
 
@@ -60,6 +65,6 @@ public class CMIFutureBatcher {
     }
 
     public boolean isRunning() {
-        return running;
+        return running.get();
     }
 }

--- a/src/main/java/net/Zrips/CMILib/GUI/CMIGuiButton.java
+++ b/src/main/java/net/Zrips/CMILib/GUI/CMIGuiButton.java
@@ -180,13 +180,13 @@ public class CMIGuiButton {
     }
 
     public void startAutoUpdate(int intervalTicks) {
-        updateInterval = intervalTicks;
+        updateInterval = Math.max(1, intervalTicks);
         tasker();
     }
 
     @Deprecated
     public void startAutoUpdate(CMIGui sgui, int intervalTicks) {
-        updateInterval = intervalTicks;
+        updateInterval = Math.max(1, intervalTicks);
         this.sgui = sgui;
         tasker();
     }

--- a/src/main/java/net/Zrips/CMILib/Images/CMIImage.java
+++ b/src/main/java/net/Zrips/CMILib/Images/CMIImage.java
@@ -144,6 +144,8 @@ public class CMIImage {
         BufferedImage res = null;
         try {
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
             stream = connection.getInputStream();
             res = ImageIO.read(stream);
 

--- a/src/main/java/net/Zrips/CMILib/Items/CMIMaterial.java
+++ b/src/main/java/net/Zrips/CMILib/Items/CMIMaterial.java
@@ -2156,7 +2156,7 @@ public enum CMIMaterial {
             }
 
         idMap.put(id, mat);
-        return CMIMaterial.NONE;
+        return mat;
     }
 
     public static @NotNull CMIMaterial get(ItemStack item) {

--- a/src/main/java/net/Zrips/CMILib/Items/ItemManager.java
+++ b/src/main/java/net/Zrips/CMILib/Items/ItemManager.java
@@ -42,6 +42,8 @@ public class ItemManager {
     private CMILib plugin;
 
     static HashMap<Material, CMIMaterial> byRealMaterial = new HashMap<Material, CMIMaterial>();
+    private static final Pattern TAG_PATTERN = Pattern.compile("(\\{).+(\\})");
+
     static HashMap<String, CMIMaterial> byName = new HashMap<String, CMIMaterial>();
     private static HashMap<String, Material> byNameMaterial = new HashMap<String, Material>();
 
@@ -211,8 +213,7 @@ public class ItemManager {
 
         String tag = null;
         if (name.contains("{") && name.contains("}")) {
-            Pattern ptr = Pattern.compile("(\\{).+(\\})");
-            Matcher match = ptr.matcher(name);
+            Matcher match = TAG_PATTERN.matcher(name);
             if (match.find()) {
                 tag = match.group();
                 name = name.replace(match.group(), "");

--- a/src/main/java/net/Zrips/CMILib/NBT/CMINBTLegacy.java
+++ b/src/main/java/net/Zrips/CMILib/NBT/CMINBTLegacy.java
@@ -530,17 +530,16 @@ public class CMINBTLegacy implements CMINBTInterface {
 
     public Integer getInt(String path) {
 
-        if (!this.hasNBT(path))
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return null;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                Integer v = persistentDataContainer.getInt(path);
-                if (v != null)
-                    return v;
-            }
+        if (persistentDataContainer != null) {
+            Integer v = persistentDataContainer.getInt(path);
+            if (v != null)
+                return v;
         }
 
         try {
@@ -552,17 +551,17 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public Byte getByte(String path) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return null;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                Byte v = CMIPersistentDataContainer.get(object).getByte(path);
-                if (v != null)
-                    return v;
-            }
+        if (persistentDataContainer != null) {
+            Byte v = persistentDataContainer.getByte(path);
+            if (v != null)
+                return v;
         }
 
         try {
@@ -574,18 +573,18 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public Long getLong(String path) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return null;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                Long v = persistentDataContainer.getLong(path);
+        if (persistentDataContainer != null) {
+            Long v = persistentDataContainer.getLong(path);
 
-                if (v != null)
-                    return v;
-            }
+            if (v != null)
+                return v;
         }
 
         try {
@@ -597,18 +596,18 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public Boolean getBoolean(String path) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return null;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                Boolean v = persistentDataContainer.getBoolean(path);
+        if (persistentDataContainer != null) {
+            Boolean v = persistentDataContainer.getBoolean(path);
 
-                if (v != null)
-                    return v;
-            }
+            if (v != null)
+                return v;
         }
 
         try {
@@ -620,18 +619,18 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public float getFloat(String path) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return 0.0F;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                Float v = persistentDataContainer.getFloat(path);
+        if (persistentDataContainer != null) {
+            Float v = persistentDataContainer.getFloat(path);
 
-                if (v != null)
-                    return v;
-            }
+            if (v != null)
+                return v;
         }
 
         try {
@@ -666,18 +665,18 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public double getDouble(String path) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return 0.0D;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                Double v = persistentDataContainer.getDouble(path);
+        if (persistentDataContainer != null) {
+            Double v = persistentDataContainer.getDouble(path);
 
-                if (v != null)
-                    return v;
-            }
+            if (v != null)
+                return v;
         }
 
         try {
@@ -689,18 +688,18 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public byte[] getByteArray(String path) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return new byte[0];
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                byte[] v = persistentDataContainer.getByteArray(path);
+        if (persistentDataContainer != null) {
+            byte[] v = persistentDataContainer.getByteArray(path);
 
-                if (v != null)
-                    return v;
-            }
+            if (v != null)
+                return v;
         }
 
         try {
@@ -740,17 +739,16 @@ public class CMINBTLegacy implements CMINBTInterface {
 
     public String getString(String path) {
 
-        if (!this.hasNBT(path))
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return null;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                String v = persistentDataContainer.getString(path);
-                if (v != null) {
-                    return v;
-                }
+        if (persistentDataContainer != null) {
+            String v = persistentDataContainer.getString(path);
+            if (v != null) {
+                return v;
             }
         }
 
@@ -787,17 +785,17 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public List<String> getList(String path, int type) {
-        if (!this.hasNBT(path))
+
+        @Nullable
+        CMIPersistentDataContainer persistentDataContainer = Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null;
+
+        if (!this.hasNBT(path, persistentDataContainer))
             return null;
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
-            if (persistentDataContainer != null) {
-                List<String> v = persistentDataContainer.getListString(path);
-                if (v != null) {
-                    return new ArrayList<String>(v);
-                }
+        if (persistentDataContainer != null) {
+            List<String> v = persistentDataContainer.getListString(path);
+            if (v != null) {
+                return new ArrayList<String>(v);
             }
         }
 
@@ -1483,13 +1481,13 @@ public class CMINBTLegacy implements CMINBTInterface {
     }
 
     public boolean hasNBT(String key) {
+        return hasNBT(key, Version.isCurrentEqualOrHigher(Version.v1_20_R4) ? CMIPersistentDataContainer.get(object) : null);
+    }
 
-        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4)) {
-            @Nullable
-            CMIPersistentDataContainer persistent = CMIPersistentDataContainer.get(object);
-            if (persistent != null && persistent.hasKey(key))
-                return true;
-        }
+    private boolean hasNBT(String key, @Nullable CMIPersistentDataContainer persistent) {
+
+        if (persistent != null && persistent.hasKey(key))
+            return true;
 
         Object t = updateLegacyTag(tag);
 

--- a/src/main/java/net/Zrips/CMILib/NBT/CMINBTMojang.java
+++ b/src/main/java/net/Zrips/CMILib/NBT/CMINBTMojang.java
@@ -208,6 +208,8 @@ public class CMINBTMojang implements CMINBTInterface {
     Object tag;
     Object object;
 
+    private boolean tagComputed = false;
+
     private nmbtType type;
 
     static {
@@ -225,7 +227,6 @@ public class CMINBTMojang implements CMINBTInterface {
 
     public CMINBTMojang(ItemStack item) {
         object = item;
-        tag = getNbt(item);
         type = nmbtType.item;
     }
 
@@ -277,11 +278,12 @@ public class CMINBTMojang implements CMINBTInterface {
 
     public Integer getInt(String path) {
 
-        if (!this.hasNBT(path))
-            return null;
-
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return null;
+
         if (persistentDataContainer != null) {
             Integer v = persistentDataContainer.getInt(path);
             if (v != null)
@@ -298,13 +300,15 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public Byte getByte(String path) {
-        if (!this.hasNBT(path))
-            return null;
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return null;
+
         if (persistentDataContainer != null) {
-            Byte v = CMIPersistentDataContainer.get(object).getByte(path);
+            Byte v = persistentDataContainer.getByte(path);
             if (v != null)
                 return v;
         }
@@ -318,11 +322,13 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public Long getLong(String path) {
-        if (!this.hasNBT(path))
-            return null;
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return null;
+
         if (persistentDataContainer != null) {
             Long v = persistentDataContainer.getLong(path);
 
@@ -339,11 +345,13 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public Boolean getBoolean(String path) {
-        if (!this.hasNBT(path))
-            return null;
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return null;
+
         if (persistentDataContainer != null) {
             Boolean v = persistentDataContainer.getBoolean(path);
 
@@ -360,11 +368,13 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public float getFloat(String path) {
-        if (!this.hasNBT(path))
-            return 0.0F;
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return 0.0F;
+
         if (persistentDataContainer != null) {
             Float v = persistentDataContainer.getFloat(path);
 
@@ -390,7 +400,7 @@ public class CMINBTMojang implements CMINBTInterface {
                 return v;
         }
 
-        if (tag == null)
+        if (getTag() == null)
             return null;
 
         try {
@@ -402,11 +412,13 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public double getDouble(String path) {
-        if (!this.hasNBT(path))
-            return 0.0D;
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return 0.0D;
+
         if (persistentDataContainer != null) {
             Double v = persistentDataContainer.getDouble(path);
 
@@ -423,11 +435,13 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public byte[] getByteArray(String path) {
-        if (!this.hasNBT(path))
-            return new byte[0];
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return new byte[0];
+
         if (persistentDataContainer != null) {
             byte[] v = persistentDataContainer.getByteArray(path);
 
@@ -469,11 +483,12 @@ public class CMINBTMojang implements CMINBTInterface {
 
     public String getString(String path) {
 
-        if (!this.hasNBT(path))
-            return null;
-
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return null;
+
         if (persistentDataContainer != null) {
             String v = persistentDataContainer.getString(path);
             if (v != null) {
@@ -517,11 +532,13 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public List<String> getList(String path, int type) {
-        if (!this.hasNBT(path))
-            return null;
 
         @Nullable
         CMIPersistentDataContainer persistentDataContainer = CMIPersistentDataContainer.get(object);
+
+        if (!this.hasNBT(path, persistentDataContainer))
+            return null;
+
         if (persistentDataContainer != null) {
             List<String> v = persistentDataContainer.getListString(path);
             if (v != null) {
@@ -745,6 +762,7 @@ public class CMINBTMojang implements CMINBTInterface {
 
         if (getType().equals(nmbtType.item)) {
             tag = getNbt((ItemStack) object);
+            tagComputed = true;
         }
 
         return removeItemTag(path);
@@ -772,12 +790,14 @@ public class CMINBTMojang implements CMINBTInterface {
     }
 
     public boolean hasNBT() {
-        return tag != null;
+        return getTag() != null;
     }
 
     public boolean hasNBT(String key) {
-        @Nullable
-        CMIPersistentDataContainer persistent = CMIPersistentDataContainer.get(object);
+        return hasNBT(key, CMIPersistentDataContainer.get(object));
+    }
+
+    private boolean hasNBT(String key, @Nullable CMIPersistentDataContainer persistent) {
         if (persistent != null && persistent.hasKey(key))
             return true;
 
@@ -793,8 +813,16 @@ public class CMINBTMojang implements CMINBTInterface {
         return contains;
     }
 
-    public Object getNbt() {
+    private Object getTag() {
+        if (!tagComputed && type == nmbtType.item && object instanceof ItemStack) {
+            tag = getNbt((ItemStack) object);
+            tagComputed = true;
+        }
         return tag;
+    }
+
+    public Object getNbt() {
+        return getTag();
     }
 
     public Set<String> getKeys() {

--- a/src/main/java/net/Zrips/CMILib/Permissions/CMILPerm.java
+++ b/src/main/java/net/Zrips/CMILib/Permissions/CMILPerm.java
@@ -1,8 +1,10 @@
 package net.Zrips.CMILib.Permissions;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -231,10 +233,15 @@ public enum CMILPerm {
 	return false;
     }
 
-    private static HashMap<UUID, HashMap<String, PermissionInfo>> cache = new HashMap<UUID, HashMap<String, PermissionInfo>>();
+    private static Map<UUID, HashMap<String, PermissionInfo>> cache = new ConcurrentHashMap<UUID, HashMap<String, PermissionInfo>>();
 
     public void removeFromCache(Player player) {
 	cache.remove(player.getUniqueId());
+    }
+
+    public static void removeFromCache(UUID uuid) {
+	if (uuid != null)
+	    cache.remove(uuid);
     }
 
     public PermissionInfo getFromCache(Player player, String perm) {

--- a/src/main/java/net/Zrips/CMILib/Permissions/CMILPerm.java
+++ b/src/main/java/net/Zrips/CMILib/Permissions/CMILPerm.java
@@ -233,7 +233,7 @@ public enum CMILPerm {
 	return false;
     }
 
-    private static Map<UUID, HashMap<String, PermissionInfo>> cache = new ConcurrentHashMap<UUID, HashMap<String, PermissionInfo>>();
+    private static Map<UUID, Map<String, PermissionInfo>> cache = new ConcurrentHashMap<UUID, Map<String, PermissionInfo>>();
 
     public void removeFromCache(Player player) {
 	cache.remove(player.getUniqueId());
@@ -245,7 +245,7 @@ public enum CMILPerm {
     }
 
     public PermissionInfo getFromCache(Player player, String perm) {
-	HashMap<String, PermissionInfo> old = cache.get(player.getUniqueId());
+	Map<String, PermissionInfo> old = cache.get(player.getUniqueId());
 	if (old == null) {
 	    return null;
 	}
@@ -260,17 +260,13 @@ public enum CMILPerm {
     }
 
     public PermissionInfo addToCache(Player player, String perm, boolean has, Long delayInMiliseconds) {
-	HashMap<String, PermissionInfo> old = cache.get(player.getUniqueId());
-	if (old == null) {
-	    old = new HashMap<String, PermissionInfo>();
-	}
+	Map<String, PermissionInfo> old = cache.computeIfAbsent(player.getUniqueId(), k -> new ConcurrentHashMap<String, PermissionInfo>());
 
 	PermissionInfo info = new PermissionInfo(perm, delayInMiliseconds);
 	info.setLastChecked(System.currentTimeMillis());
 	info.setEnabled(has);
 
 	old.put(perm, info);
-	cache.put(player.getUniqueId(), old);
 
 	return info;
     }
@@ -309,9 +305,7 @@ public enum CMILPerm {
 	if (player == null)
 	    return new PermissionInfo(perm, delay);
 
-	HashMap<String, PermissionInfo> c = cache.get(player.getUniqueId());
-	if (c == null)
-	    c = new HashMap<String, PermissionInfo>();
+	Map<String, PermissionInfo> c = cache.computeIfAbsent(player.getUniqueId(), k -> new ConcurrentHashMap<String, PermissionInfo>());
 
 	PermissionInfo p = c.get(perm);
 
@@ -357,7 +351,6 @@ public enum CMILPerm {
 	}
 	p.setLastChecked(System.currentTimeMillis());
 	c.put(perm, p);
-	cache.put(player.getUniqueId(), c);
 	return p;
     }
 

--- a/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
@@ -9,6 +9,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -330,7 +331,7 @@ public class Placeholder {
                     if (!message.contains("%"))
                         break;
                     String group = match.group();
-                    int id = (new Random()).nextInt(Integer.MAX_VALUE);
+                    int id = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
                     String with = "|" + id + "|";
                     temp.put(with, group);
                     message = message.replaceFirst(Matcher.quoteReplacement(group), Matcher.quoteReplacement(with));
@@ -461,7 +462,7 @@ public class Placeholder {
                     if (!message.contains("%"))
                         break;
                     String group = match.group();
-                    int id = (new Random()).nextInt(Integer.MAX_VALUE);
+                    int id = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
                     String with = "|" + id + "|";
                     temp.put(with, group);
                     message = message.replaceFirst(Matcher.quoteReplacement(group), Matcher.quoteReplacement(with));
@@ -486,7 +487,7 @@ public class Placeholder {
                         break;
                     String group = matchKeep.group();
 
-                    int id = (new Random()).nextInt(Integer.MAX_VALUE);
+                    int id = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
 
                     String with = "|" + id + "|";
 

--- a/src/main/java/net/Zrips/CMILib/RawMessages/RawMessage.java
+++ b/src/main/java/net/Zrips/CMILib/RawMessages/RawMessage.java
@@ -843,51 +843,51 @@ public class RawMessage {
 
     public List<String> softCombine() {
         List<String> ls = new ArrayList<String>();
-        String f = "";
+        StringBuilder f = new StringBuilder();
         for (String part : parts) {
-            if (f.isEmpty())
-                f = "[\"\",";
+            if (f.length() == 0)
+                f.append("[\"\",");
             else {
                 if (f.length() > 30000) {
-                    ls.add(f + "]");
-                    f = "[\"\"," + part;
+                    ls.add(f.toString() + "]");
+                    f = new StringBuilder("[\"\",").append(part);
                     continue;
                 }
-                f += ",";
+                f.append(",");
             }
-            f += part;
+            f.append(part);
         }
-        if (!f.isEmpty())
-            f += "]";
-        ls.add(f);
+        if (f.length() != 0)
+            f.append("]");
+        ls.add(f.toString());
         return ls;
     }
 
     private RawMessage combine() {
-        String f = "";
+        StringBuilder f = new StringBuilder();
         for (String part : parts) {
-            if (f.isEmpty())
-                f = "[\"\",";
+            if (f.length() == 0)
+                f.append("[\"\",");
             else
-                f += ",";
-            f += part;
+                f.append(",");
+            f.append(part);
         }
-        if (!f.isEmpty())
-            f += "]";
+        if (f.length() != 0)
+            f.append("]");
 
-        if (f.isEmpty())
-            f = "{\"text\":\" \"}";
-
-        combined = f;
+        if (f.length() == 0)
+            combined = "{\"text\":\" \"}";
+        else
+            combined = f.toString();
         return this;
     }
 
     public RawMessage combineClean() {
-        String f = "";
+        StringBuilder f = new StringBuilder();
         for (String part : onlyText) {
-            f += part.replace("\\\"", "\"");
+            f.append(part.replace("\\\"", "\""));
         }
-        combinedClean = f;
+        combinedClean = f.toString();
         return this;
     }
 
@@ -946,23 +946,23 @@ public class RawMessage {
     }
 
     public int getFinalLength() {
-        String f = "";
+        StringBuilder f = new StringBuilder();
         for (String part : parts) {
-            if (f.isEmpty())
-                f = "[\"\",";
+            if (f.length() == 0)
+                f.append("[\"\",");
             else
-                f += ",";
-            f += part;
+                f.append(",");
+            f.append(part);
         }
         for (String part : temp.values()) {
-            if (f.isEmpty())
-                f = "[\"\",";
+            if (f.length() == 0)
+                f.append("[\"\",");
             else
-                f += ",";
-            f += part;
+                f.append(",");
+            f.append(part);
         }
-        if (!f.isEmpty())
-            f += "]";
+        if (f.length() != 0)
+            f.append("]");
         return f.length();
     }
 
@@ -1019,15 +1019,13 @@ public class RawMessage {
 
     public String getShortRaw() {
         build();
-        String f = "";
+        StringBuilder f = new StringBuilder();
         for (String part : parts) {
-            if (!f.isEmpty())
-                f += ",";
-            f += part;
+            if (f.length() != 0)
+                f.append(",");
+            f.append(part);
         }
-        f = truncate(f);
-
-        return f;
+        return truncate(f.toString());
     }
 
     public boolean isDontBreakLine() {

--- a/src/main/java/net/Zrips/CMILib/Shadow/ShadowCommandListener.java
+++ b/src/main/java/net/Zrips/CMILib/Shadow/ShadowCommandListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.server.ServerCommandEvent;
 
 import net.Zrips.CMILib.CMILib;
 import net.Zrips.CMILib.Locale.Snd;
+import net.Zrips.CMILib.Permissions.CMILPerm;
 import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
 
 public class ShadowCommandListener implements Listener {
@@ -17,6 +18,7 @@ public class ShadowCommandListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerQuitEvent(PlayerQuitEvent event) {
         ShadowCommand.remove(event.getPlayer().getUniqueId());
+        CMILPerm.removeFromCache(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/src/main/java/net/Zrips/CMILib/Skins/CMISkin.java
+++ b/src/main/java/net/Zrips/CMILib/Skins/CMISkin.java
@@ -213,8 +213,11 @@ public class CMISkin {
         }
         InputStream stream = null;
         BufferedImage res = null;
+        HttpURLConnection connection = null;
         try {
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
             stream = connection.getInputStream();
             res = ImageIO.read(stream);
         } catch (Throwable e) {
@@ -226,6 +229,8 @@ public class CMISkin {
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
+            if (connection != null)
+                connection.disconnect();
         }
         return res;
     }

--- a/src/main/java/net/Zrips/CMILib/Skins/SkinManager.java
+++ b/src/main/java/net/Zrips/CMILib/Skins/SkinManager.java
@@ -9,7 +9,6 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -30,10 +29,10 @@ import net.Zrips.CMILib.Messages.CMIMessages;
 import net.Zrips.CMILib.Version.Version;
 
 public class SkinManager {
-    public ConcurrentHashMap<UUID, CMISkin> skinCacheByUUID = new ConcurrentHashMap<UUID, CMISkin>();
-    public ConcurrentHashMap<String, CMISkin> skinCacheByName = new ConcurrentHashMap<String, CMISkin>();
+    public HashMap<UUID, CMISkin> skinCacheByUUID = new HashMap<UUID, CMISkin>();
+    public HashMap<String, CMISkin> skinCacheByName = new HashMap<String, CMISkin>();
 
-    protected ConcurrentHashMap<String, List<String>> preFetchNames = new ConcurrentHashMap<String, List<String>>();
+    protected HashMap<String, List<String>> preFetchNames = new HashMap<String, List<String>>();
     protected HashMap<String, UUID> preFetchUUIDs = new HashMap<String, UUID>();
 
     CMILib plugin;

--- a/src/main/java/net/Zrips/CMILib/Skins/SkinManager.java
+++ b/src/main/java/net/Zrips/CMILib/Skins/SkinManager.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -29,10 +30,10 @@ import net.Zrips.CMILib.Messages.CMIMessages;
 import net.Zrips.CMILib.Version.Version;
 
 public class SkinManager {
-    public HashMap<UUID, CMISkin> skinCacheByUUID = new HashMap<UUID, CMISkin>();
-    public HashMap<String, CMISkin> skinCacheByName = new HashMap<String, CMISkin>();
+    public ConcurrentHashMap<UUID, CMISkin> skinCacheByUUID = new ConcurrentHashMap<UUID, CMISkin>();
+    public ConcurrentHashMap<String, CMISkin> skinCacheByName = new ConcurrentHashMap<String, CMISkin>();
 
-    protected HashMap<String, List<String>> preFetchNames = new HashMap<String, List<String>>();
+    protected ConcurrentHashMap<String, List<String>> preFetchNames = new ConcurrentHashMap<String, List<String>>();
     protected HashMap<String, UUID> preFetchUUIDs = new HashMap<String, UUID>();
 
     CMILib plugin;
@@ -93,6 +94,8 @@ public class SkinManager {
             HttpsURLConnection connection = (HttpsURLConnection) new URL(
                     String.format("https://sessionserver.mojang.com/session/minecraft/profile/%s?unsigned=false", uuid.toString().replace("-", "")))
                     .openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
             if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 InputStream stream = connection.getInputStream();
                 BufferedReader buffer = new BufferedReader(new InputStreamReader(stream));
@@ -268,6 +271,8 @@ public class SkinManager {
         try {
             URL url = new URL(target);
             connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
             connection.setRequestMethod("GET");
             connection.setUseCaches(false);
             connection.setDoOutput(true);


### PR DESCRIPTION
Hi, @Zrips! 

Performance:
- Lazy NBT tag and no duplicate ItemMeta reads - avoids a full item codec serialization on every NBT access on 1.20.5+
- Cache compiled regex patterns, reuse StringBuilder/Matcher and ThreadLocalRandom across text/color/placeholder hot paths
- Fetch the chunk/block once and drop Location.clone() allocations in cuboid scans
- Cache enum values() arrays in CMIBlock direction/stair lookups

Fixes:
- CMIBlock.getInventory no longer leaks force-loaded chunks (setForceLoaded was never cleared)
- CMIMaterial.get(int) returned NONE instead of the material it found
- Skin/image caches are thread-safe now (ConcurrentHashMap) and all Mojang/minotar/minepic requests get connect/read timeouts
- Fixed a race in CMIFutureBatcher that could leave a queued future unprocessed
- Permission cache is thread-safe and cleared on quit instead of growing forever
- Advancement revoke runs on the player's own region so it works on Folia
- Clamp GUI button auto-update interval to avoid a scheduler crash when <= 0

Each change is its own commit. Compiles clean, no behavior changes.
