### PR TITLE
Add {command} placeholder

### DIFF
--- a/src/main/java/net/Zrips/CMILib/CMILib.java
+++ b/src/main/java/net/Zrips/CMILib/CMILib.java
@@ -25,6 +25,7 @@ import net.Zrips.CMILib.Locale.Language;
 import net.Zrips.CMILib.Logs.CMIDebug;
 import net.Zrips.CMILib.Logs.CMILogManager;
 import net.Zrips.CMILib.Messages.CMIMessages;
+import net.Zrips.CMILib.Placeholders.CommandPlaceholderListener;
 import net.Zrips.CMILib.Placeholders.Placeholder;
 import net.Zrips.CMILib.Placeholders.PlaceholderAPIHook;
 import net.Zrips.CMILib.RawMessages.RawMessageListener;
@@ -298,6 +299,7 @@ public class CMILib extends JavaPlugin {
         pm.registerEvents(new RawMessageListener(), this);
         pm.registerEvents(new ShadowCommandListener(), this);
         pm.registerEvents(new WorldsListener(), this);
+        pm.registerEvents(new CommandPlaceholderListener(), this);
         getCommandManager().fillCommands();
 
         // Primary initialization to record locale

--- a/src/main/java/net/Zrips/CMILib/Locale/Language.java
+++ b/src/main/java/net/Zrips/CMILib/Locale/Language.java
@@ -190,7 +190,7 @@ public class Language {
         if (msg == null)
             return null;
 
-        if (!msg.contains("[")) {
+        if (!msg.contains("[") && !msg.contains("{") && !msg.contains("%")) {
             msg = this.filterNewLine(msg);
             return msg;
         }
@@ -267,7 +267,7 @@ public class Language {
     public String updateCmiSnd(com.Zrips.CMI.Containers.Snd snd, String msg) {
         if (msg == null)
             return null;
-        if (!msg.contains("[")) {
+        if (!msg.contains("[") && !msg.contains("{") && !msg.contains("%")) {
             msg = this.filterNewLine(msg);
             return msg;
         }

--- a/src/main/java/net/Zrips/CMILib/Permissions/CMILPerm.java
+++ b/src/main/java/net/Zrips/CMILib/Permissions/CMILPerm.java
@@ -155,7 +155,7 @@ public enum CMILPerm {
 	if (!has && inform) {
 	    boolean showPerm = CMILibConfig.permisionOnError || CMILPerm.permisiononerror.hasPermission(sender);
 	    RawMessage rm = new RawMessage();
-	    rm.add(CMIMessages.getMsg(LC.info_NoPermission), showPerm ? perm : null);
+	    rm.add(CMIMessages.getMsg(LC.info_NoPermission, player), showPerm ? perm : null);
 	    rm.show(sender);
 
 	    informConsole(sender, perm, informConsole);
@@ -184,7 +184,7 @@ public enum CMILPerm {
 	if (!has && inform) {
 	    boolean showPerm = CMILibConfig.permisionOnError || CMILPerm.permisiononerror.hasPermission(sender);
 	    RawMessage rm = new RawMessage();
-	    rm.add(CMIMessages.getMsg(LC.info_NoPermission), showPerm ? perm : null);
+	    rm.add(CMIMessages.getMsg(LC.info_NoPermission, sender instanceof Player ? (Player) sender : null), showPerm ? perm : null);
 	    rm.show(sender);
 
 	    informConsole(sender, perm, true);
@@ -223,7 +223,7 @@ public enum CMILPerm {
 	if (output) {
 	    boolean showPerm = CMILibConfig.permisionOnError || CMILPerm.permisiononerror.hasPermission(sender);
 	    RawMessage rm = new RawMessage();
-	    rm.addText(CMIMessages.getMsg(LC.info_NoPermission)).addHover(showPerm ? permision : null);
+	    rm.addText(CMIMessages.getMsg(LC.info_NoPermission, player)).addHover(showPerm ? permision : null);
 	    rm.show(sender);
 
 	    informConsole(sender, permision, informConsole);

--- a/src/main/java/net/Zrips/CMILib/Placeholders/CommandPlaceholderListener.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/CommandPlaceholderListener.java
@@ -7,6 +7,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import net.Zrips.CMILib.Messages.CMIMessages;
+
 /**
  * Keeps track of the last command each player performed so it can be
  * exposed through the {command} placeholder (returns the command without
@@ -18,6 +20,8 @@ public class CommandPlaceholderListener implements Listener {
     public void onCommand(PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
         Placeholder.setLastCommand(player.getUniqueId(), event.getMessage());
+        CMIMessages.consoleMessage("&e[CMIL-DEBUG] Cached last command for " + player.getName() + ": '" + event.getMessage() + "' -> stored as '"
+                + Placeholder.getLastCommand(player.getUniqueId()) + "'");
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/net/Zrips/CMILib/Placeholders/CommandPlaceholderListener.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/CommandPlaceholderListener.java
@@ -7,8 +7,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import net.Zrips.CMILib.Messages.CMIMessages;
-
 /**
  * Keeps track of the last command each player performed so it can be
  * exposed through the {command} placeholder (returns the command without
@@ -20,8 +18,6 @@ public class CommandPlaceholderListener implements Listener {
     public void onCommand(PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
         Placeholder.setLastCommand(player.getUniqueId(), event.getMessage());
-        CMIMessages.consoleMessage("&e[CMIL-DEBUG] Cached last command for " + player.getName() + ": '" + event.getMessage() + "' -> stored as '"
-                + Placeholder.getLastCommand(player.getUniqueId()) + "'");
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/net/Zrips/CMILib/Placeholders/CommandPlaceholderListener.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/CommandPlaceholderListener.java
@@ -1,0 +1,27 @@
+package net.Zrips.CMILib.Placeholders;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Keeps track of the last command each player performed so it can be
+ * exposed through the {command} placeholder (returns the command without
+ * the leading /).
+ */
+public class CommandPlaceholderListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = false)
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        Player player = event.getPlayer();
+        Placeholder.setLastCommand(player.getUniqueId(), event.getMessage());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onQuit(PlayerQuitEvent event) {
+        Placeholder.removeLastCommand(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
@@ -39,6 +39,8 @@ public class Placeholder {
     Random random = new Random(System.nanoTime());
 
     public enum CMIPlaceHolders {
+
+        command("Returns the command the player performed, without the leading /"),
         ;
 
         static LinkedHashMap<String, CMIPlaceHolders> byNameStatic = new LinkedHashMap<String, CMIPlaceHolders>();
@@ -529,6 +531,32 @@ public class Placeholder {
 
     private HashMap<String, String> randomCache = new HashMap<String, String>();
 
+    private static final HashMap<UUID, String> lastCommands = new HashMap<UUID, String>();
+
+    /**
+     * Stores the last command a player performed so it can later be read back
+     * through the {command} placeholder. The leading / is stripped.
+     */
+    public static void setLastCommand(UUID uuid, String command) {
+        if (uuid == null || command == null)
+            return;
+
+        if (command.startsWith("/"))
+            command = command.substring(1);
+
+        lastCommands.put(uuid, command);
+    }
+
+    public static String getLastCommand(UUID uuid) {
+        if (uuid == null)
+            return null;
+        return lastCommands.get(uuid);
+    }
+
+    public static void removeLastCommand(UUID uuid) {
+        lastCommands.remove(uuid);
+    }
+
     public String getValue(Player player, CMIPlaceHolders placeHolder) {
         return getValue(player, placeHolder, null);
     }
@@ -538,6 +566,16 @@ public class Placeholder {
     }
 
     public String getValue(UUID uuid, CMIPlaceHolders placeHolder, String value) {
+        if (placeHolder == null)
+            return null;
+
+        switch (placeHolder) {
+        case command:
+            return getLastCommand(uuid);
+        default:
+            break;
+        }
+
         return null;
     }
 

--- a/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
@@ -405,6 +405,9 @@ public class Placeholder {
                         break;
 
                     CMIPlaceHolders place = CMIPlaceHolders.getByNameExact(cmd);
+                    if (cmd.equalsIgnoreCase("command")) {
+                        CMIMessages.consoleMessage("&e[CMIL-DEBUG] matchInception saw '{" + cmd + "}', resolved enum = " + place);
+                    }
                     if (place == null) {
                         if (plugin.isPlaceholderAPIEnabled()) {
                             try {
@@ -431,11 +434,15 @@ public class Placeholder {
 
                     String group = match.group();
                     String with = this.getValue(uuid, place, group);
+                    if (cmd.equalsIgnoreCase("command")) {
+                        CMIMessages.consoleMessage("&e[CMIL-DEBUG] {command} getValue() returned: '" + with + "' for uuid " + uuid);
+                    }
                     if (with == null)
                         with = "";
                     message = message.replaceFirst(Matcher.quoteReplacement(group), Matcher.quoteReplacement(with));
                 }
             } catch (Throwable e) {
+                CMIMessages.consoleMessage("&c[CMIL-DEBUG] matchInception threw: " + e);
             }
         }
 
@@ -446,10 +453,21 @@ public class Placeholder {
         if (message == null)
             return null;
 
+        boolean hadCommandToken = message.toLowerCase().contains("{command}");
+        if (hadCommandToken) {
+            CMIMessages.consoleMessage("&e[CMIL-DEBUG] translateOwnPlaceHolder start, isCmiPresent=" + CMILib.getInstance().isCmiPresent() + ", msg='" + message + "'");
+        }
+
         if (CMILib.getInstance().isCmiPresent()) {
             try {
                 message = com.Zrips.CMI.CMI.getInstance().getPlaceholderAPIManager().translateOwnPlaceHolder(uuid, message);
+                if (hadCommandToken) {
+                    CMIMessages.consoleMessage("&e[CMIL-DEBUG] after CMI delegation: '" + message + "'");
+                }
             } catch (Throwable e) {
+                if (hadCommandToken) {
+                    CMIMessages.consoleMessage("&c[CMIL-DEBUG] CMI delegation threw: " + e);
+                }
             }
         }
 

--- a/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
@@ -439,7 +439,7 @@ public class Placeholder {
                     }
                     if (with == null)
                         with = "";
-                    message = message.replaceFirst(Matcher.quoteReplacement(group), Matcher.quoteReplacement(with));
+                    message = message.replaceFirst(Pattern.quote(group), Matcher.quoteReplacement(with));
                 }
             } catch (Throwable e) {
                 CMIMessages.consoleMessage("&c[CMIL-DEBUG] matchInception threw: " + e);

--- a/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
+++ b/src/main/java/net/Zrips/CMILib/Placeholders/Placeholder.java
@@ -405,9 +405,6 @@ public class Placeholder {
                         break;
 
                     CMIPlaceHolders place = CMIPlaceHolders.getByNameExact(cmd);
-                    if (cmd.equalsIgnoreCase("command")) {
-                        CMIMessages.consoleMessage("&e[CMIL-DEBUG] matchInception saw '{" + cmd + "}', resolved enum = " + place);
-                    }
                     if (place == null) {
                         if (plugin.isPlaceholderAPIEnabled()) {
                             try {
@@ -434,15 +431,11 @@ public class Placeholder {
 
                     String group = match.group();
                     String with = this.getValue(uuid, place, group);
-                    if (cmd.equalsIgnoreCase("command")) {
-                        CMIMessages.consoleMessage("&e[CMIL-DEBUG] {command} getValue() returned: '" + with + "' for uuid " + uuid);
-                    }
                     if (with == null)
                         with = "";
                     message = message.replaceFirst(Pattern.quote(group), Matcher.quoteReplacement(with));
                 }
             } catch (Throwable e) {
-                CMIMessages.consoleMessage("&c[CMIL-DEBUG] matchInception threw: " + e);
             }
         }
 
@@ -453,21 +446,10 @@ public class Placeholder {
         if (message == null)
             return null;
 
-        boolean hadCommandToken = message.toLowerCase().contains("{command}");
-        if (hadCommandToken) {
-            CMIMessages.consoleMessage("&e[CMIL-DEBUG] translateOwnPlaceHolder start, isCmiPresent=" + CMILib.getInstance().isCmiPresent() + ", msg='" + message + "'");
-        }
-
         if (CMILib.getInstance().isCmiPresent()) {
             try {
                 message = com.Zrips.CMI.CMI.getInstance().getPlaceholderAPIManager().translateOwnPlaceHolder(uuid, message);
-                if (hadCommandToken) {
-                    CMIMessages.consoleMessage("&e[CMIL-DEBUG] after CMI delegation: '" + message + "'");
-                }
             } catch (Throwable e) {
-                if (hadCommandToken) {
-                    CMIMessages.consoleMessage("&c[CMIL-DEBUG] CMI delegation threw: " + e);
-                }
             }
         }
 

--- a/src/main/java/net/Zrips/CMILib/commands/CommandsHandler.java
+++ b/src/main/java/net/Zrips/CMILib/commands/CommandsHandler.java
@@ -118,7 +118,7 @@ public class CommandsHandler implements CommandExecutor {
             if (cmiSender.isPlayer()) {
                 boolean showPerm = CMILibConfig.permisionOnError || CMILPerm.permisiononerror.hasPermission(sender, false, 5000L);
                 RawMessage rm = new RawMessage();
-                rm.addText(CMIMessages.getMsg(LC.info_NoPermission)).addHover(showPerm ? "&2" + CMILPerm.command.getPermission() : null);
+                rm.addText(CMIMessages.getMsg(LC.info_NoPermission, cmiSender.getPlayer())).addHover(showPerm ? "&2" + CMILPerm.command.getPermission() : null);
                 rm.show(sender);
             }
 
@@ -203,7 +203,7 @@ public class CommandsHandler implements CommandExecutor {
                 boolean showPerm = CMILibConfig.permisionOnError || CMILPerm.permisiononerror.hasPermission(sender, false, 5000L);
 
                 RawMessage rm = new RawMessage();
-                rm.addText(CMIMessages.getMsg(LC.info_NoPermission)).addHover(showPerm ? "&2" + label + ".command." + cmd : null);
+                rm.addText(CMIMessages.getMsg(LC.info_NoPermission, cmiSender.getPlayer())).addHover(showPerm ? "&2" + label + ".command." + cmd : null);
                 rm.show(sender);
 
                 ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();


### PR DESCRIPTION
Adds a new {command} placeholder that returns the last command executed by a player, without the leading /. Implemented via a new CommandPlaceholderListener that caches the last command per player UUID.